### PR TITLE
build: add refresh dependencies and distfiles target

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "type": "module",
   "scripts": {
     "check": "tsc --noEmit",
+    "clean": "rm -rf dist && rm -rf node_modules && rm -rf bun.lock",
     "compile": "tsc",
     "dev": "wrangler dev src/server.tsx",
     "deploy": "wrangler deploy --minify src/index.tsx",


### PR DESCRIPTION
Provides a way to quickly clean up temporary files. Includes bun lockfile for dual-use in wiping out transient dependency issues when they occur.